### PR TITLE
retry config for git lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -33,3 +33,5 @@ saved_model/**/* filter=lfs diff=lfs merge=lfs -text
 *.zip filter=lfs diff=lfs merge=lfs -text
 *.zst filter=lfs diff=lfs merge=lfs -text
 *tfevents* filter=lfs diff=lfs merge=lfs -text
+*.graffle filter=lfs diff=lfs merge=lfs -text
+docs/assets/textgraphs.graffle filter=lfs diff=lfs merge=lfs -text

--- a/docs/assets/textgraphs.graffle
+++ b/docs/assets/textgraphs.graffle
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2177f30434db8dc6534ed39b3f5a9bed3b0fbd00db26afd841f6e77c788910f2
+size 1410392


### PR DESCRIPTION
trying to re-do the configuration for `git-lfs` on this repo, specifically to track OmniGraffle documents which are used for online documentation